### PR TITLE
🐛 修复 `Role` 获取的用户角色不正确的问题

### DIFF
--- a/kirami/permission.py
+++ b/kirami/permission.py
@@ -31,7 +31,7 @@ def role_permission(role: Role) -> Permission:
             sender_role = "normal" if sender_role in ("member", None) else sender_role
             user_role = Role.roles[sender_role]
         if uid := getattr(event, "user_id", None):
-            user_role = Role.get_user_role(uid, *subjects) or user_role
+            user_role = Role.get_user_role(str(uid), *subjects) or user_role
         return user_role >= role
 
     return Permission(_role)

--- a/kirami/service/access.py
+++ b/kirami/service/access.py
@@ -79,9 +79,7 @@ class Role(BaseAccess):
         self.roles.pop(self.name, None)
         await super().delete()
 
-    async def assign_user(
-        self, user_id: int | str, subject: Subject | None = None
-    ) -> None:
+    async def assign_user(self, user_id: str, subject: Subject | None = None) -> None:
         """分配用户角色。
 
         ### 参数
@@ -90,12 +88,10 @@ class Role(BaseAccess):
             subject: 范围主体，为 None 时表示全局范围
         """
         subject = subject or Subject("global", "*")
-        self.assigned[subject].add(str(user_id))
+        self.assigned[subject].add(user_id)
         await self.save()
 
-    async def revoke_user(
-        self, user_id: int | str, subject: Subject | None = None
-    ) -> None:
+    async def revoke_user(self, user_id: str, subject: Subject | None = None) -> None:
         """撤销用户角色。
 
         ### 参数
@@ -104,14 +100,14 @@ class Role(BaseAccess):
             subject: 范围主体，为 None 时撤销所有范围的角色
         """
         if subject and user_id in self.assigned[subject]:
-            self.assigned[subject].remove(str(user_id))
+            self.assigned[subject].remove(user_id)
         else:
             for subject in self.assigned:
-                self.assigned[subject].discard(str(user_id))
+                self.assigned[subject].discard(user_id)
         await self.save()
 
     @classmethod
-    def query_user(cls, user_id: int | str, *subjects: Subject) -> set[Self]:
+    def query_user(cls, user_id: str, *subjects: Subject) -> set[Self]:
         """查询用户角色。
 
         ### 参数
@@ -132,7 +128,7 @@ class Role(BaseAccess):
         return user_roles
 
     @classmethod
-    def get_user_role(cls, user_id: int | str, *subjects: Subject) -> Self | None:
+    def get_user_role(cls, user_id: str, *subjects: Subject) -> Self | None:
         """获取用户最大权限角色。
 
         ### 参数

--- a/kirami/service/controller.py
+++ b/kirami/service/controller.py
@@ -131,7 +131,7 @@ async def role_checker(
         sender_role = "normal" if sender_role in ("member", None) else sender_role
         role = Role.roles[sender_role]
     if uid := getattr(event, "user_id", None):
-        role = Role.get_user_role(uid, *subjects) or role
+        role = Role.get_user_role(str(uid), *subjects) or role
     if role >= Role.roles[ability.role.user]:
         return
     if role >= Role.roles[service.role.user]:


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将 `Role` 方法中的 `user_id` 参数类型改为 `str`

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

获取用户角色时因为 `Role` 的部分方法没有将参数中的 `user_id` 转换为 `str`，导致获取的结果不正确

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](https://github.com/A-kirami/KiramiBot/pulls) 重复
