### PR TITLE
🐛 修复加载功能时 matcher 无法正确获取的问题

### DIFF
--- a/kirami/service/manager.py
+++ b/kirami/service/manager.py
@@ -17,6 +17,7 @@ from nonebot.plugin import Plugin
 from kirami.exception import ServiceError
 from kirami.hook import on_startup
 from kirami.log import logger
+from kirami.matcher import MatcherCase
 from kirami.utils import load_data
 
 from .service import Ability, Service
@@ -173,7 +174,9 @@ class ServiceManager:
         for matcher in matchers:
             if members := inspect.getmembers(
                 matcher.module,
-                lambda x: x is matcher,  # noqa: B023
+                lambda x, m=matcher: x.matcher is m
+                if isinstance(x, MatcherCase)
+                else x is m,
             ):
                 name, _ = members[0]
             else:


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

增加 `MatcherCase` 类型判断

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

使用标准写法时，由于 KiramiBot 的事件响应器返回 `MatcherCase`，导致 `load_abilities` 方法无法正确获取 matcher

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](https://github.com/A-kirami/KiramiBot/pulls) 重复
